### PR TITLE
Provide a default empty string value for nonce

### DIFF
--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -76,7 +76,7 @@ class ImplicitGrant extends \League\OAuth2\Server\Grant\ImplicitGrant
         $result->setResponseType($this->getQueryStringParameter('response_type', $request));
         $result->setResponseMode($this->getQueryStringParameter('response_mode', $request));
 
-        $nonce = $this->getQueryStringParameter('nonce', $request);
+        $nonce = $this->getQueryStringParameter('nonce', $request, '');
 
         //In OIDC, a nonce is required for the implicit flow
         if (strlen($nonce) == 0) {


### PR DESCRIPTION
Recent PHP versions emit an error on the subsequent call to strlen() if the nonce value is null.

An alternative solution would be to change the test to:
```php
if($nonce !== null and strlen(...))
```
I do not know which one you prefer.