### PR TITLE
ImplicitGrant forgot to fill scopes

### DIFF
--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -163,6 +163,7 @@ class ImplicitGrant extends \League\OAuth2\Server\Grant\ImplicitGrant
                     );
                     if (count($claims) > 0) {
                         array_push($claimsRequested, ...$claims);
+                        $scopes[] = $scope;
                     }
                 }
 


### PR DESCRIPTION
ImplicitGrant always calls UserRepository::getAttributes with an empty scopes parameter. This patch adds scopes when they have registered claims.