### PR TITLE
Emit event when id token is populated

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -4,6 +4,7 @@ namespace Idaas\OpenID\Grant;
 
 use DateTimeImmutable;
 use Idaas\OpenID\Entities\IdToken;
+use Idaas\OpenID\IdTokenEvent;
 use Idaas\OpenID\Repositories\AccessTokenRepositoryInterface;
 use Idaas\OpenID\Repositories\ClaimRepositoryInterface;
 use Idaas\OpenID\RequestTypes\AuthenticationRequest;
@@ -198,6 +199,8 @@ class AuthCodeGrant extends \League\OAuth2\Server\Grant\AuthCodeGrant
         $idToken->setAcr($sessionInformation->getAcr());
         $idToken->setAmr($sessionInformation->getAmr());
         $idToken->setAzp($sessionInformation->getAzp());
+
+        $this->getEmitter()->emit(IdTokenEvent::TOKEN_POPULATED, $idToken);
 
         $result->setIdToken($idToken);
 

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -4,6 +4,7 @@ namespace Idaas\OpenID\Grant;
 
 use DateTimeImmutable;
 use Idaas\OpenID\Entities\IdToken;
+use Idaas\OpenID\IdTokenEvent;
 use Idaas\OpenID\Repositories\ClaimRepositoryInterface;
 use Idaas\OpenID\Repositories\UserRepositoryInterface;
 use Idaas\OpenID\RequestTypes\AuthenticationRequest;
@@ -147,8 +148,7 @@ class ImplicitGrant extends \League\OAuth2\Server\Grant\ImplicitGrant
             $idToken->setAudience($authorizationRequest->getClient()->getIdentifier());
             $idToken->setExpiration(DateTimeImmutable::createFromMutable((new \DateTime())->add($this->idTokenTTL))) ;
             $idToken->setIat(new \DateTimeImmutable());
-            // FIXME: this only works for Laravel
-            $idToken->setAuthTime(resolve(Session::class)->getAuthTime());
+            $idToken->setAuthTime(new \DateTime());
             $idToken->setNonce($authorizationRequest->getNonce());
 
             // If there is no access token returned, include the supported claims
@@ -185,6 +185,8 @@ class ImplicitGrant extends \League\OAuth2\Server\Grant\ImplicitGrant
             $idToken->setAcr($sessionInformation->getAcr());
             $idToken->setAmr($sessionInformation->getAmr());
             $idToken->setAzp($sessionInformation->getAzp());
+
+            $this->getEmitter()->emit(new IdTokenEvent(IdTokenEvent::TOKEN_POPULATED, $idToken, $this));
 
             $parameters = [];
 

--- a/src/IdTokenEvent.php
+++ b/src/IdTokenEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Idaas\OpenID;
+
+use Idaas\OpenID\Entities\IdToken;
+use League\Event\Event;
+use League\OAuth2\Server\Grant\GrantTypeInterface;
+
+class IdTokenEvent extends Event
+{
+    const TOKEN_POPULATED = 'id_token.populated';
+
+    /**
+     * @var IdToken
+     */
+    private $idToken;
+
+    /**
+     * @var GrantTypeInterface
+     */
+    private $grantType;
+
+    public function __construct($name, IdToken $idToken, GrantTypeInterface $grantType)
+    {
+        parent::__construct($name);
+        $this->idToken = $idToken;
+        $this->grantType = $grantType;
+    }
+
+    public function getIdToken()
+    {
+        return $this->idToken;
+    }
+
+    public function getGrantType()
+    {
+        return $this->grantType;
+    }
+}


### PR DESCRIPTION
Using an event allowing to further populate the id token makes better framework integration possible. This as the current implementation of the ImplicitGrant can not be used by anything other than Laravel due to the way the auth_time is implemented. Using an event allowing modifications to the token will allow framework dependent implementations for such logic. Furthermore it would allow cases where an implementation/user might always set some additional claims.