### PR TITLE
Replace bogus identifier with configuration option

### DIFF
--- a/src/Entities/IdToken.php
+++ b/src/Entities/IdToken.php
@@ -20,6 +20,7 @@ class IdToken
     protected $acr; // Authentication Context Class Reference
     protected $amr; // Authentication Methods References
     protected $azp; // Authorized party
+    protected $identifier;
 
     protected $extra = [];
 
@@ -46,7 +47,7 @@ class IdToken
             ->permittedFor($this->getAudience())
             ->expiresAt($this->getExpiration())
             ->issuedAt($this->getIat())
-            ->identifiedBy("123")
+            ->identifiedBy($this->identifier)
             ->withClaim('auth_time', $this->getAuthTime()->getTimestamp())
             ->withClaim('nonce', $this->getNonce());
 
@@ -254,6 +255,24 @@ class IdToken
     public function setIssuer($issuer)
     {
         $this->issuer = $issuer;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of identifiedBy
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Set the value of identifiedBy
+     */
+    public function setIdentifier($identifier)
+    {
+        $this->identifier = $identifier;
 
         return $this;
     }

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -201,7 +201,7 @@ class AuthCodeGrant extends \League\OAuth2\Server\Grant\AuthCodeGrant
         $idToken->setAmr($sessionInformation->getAmr());
         $idToken->setAzp($sessionInformation->getAzp());
 
-        $this->getEmitter()->emit(IdTokenEvent::TOKEN_POPULATED, $idToken);
+        $this->getEmitter()->emit(new IdTokenEvent(IdTokenEvent::TOKEN_POPULATED, $idToken, $this));
 
         $result->setIdToken($idToken);
 

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -180,6 +180,7 @@ class AuthCodeGrant extends \League\OAuth2\Server\Grant\AuthCodeGrant
         $idToken->setAudience($authCodePayload->client_id);
         $idToken->setExpiration(DateTimeImmutable::createFromMutable((new \DateTime())->add($this->idTokenTTL)));
         $idToken->setIat(new \DateTimeImmutable());
+        $idToken->setIdentifier($this->generateUniqueIdentifier());
 
         $idToken->setAuthTime(new \DateTime('@' . $authCodePayload->auth_time));
         $idToken->setNonce($authCodePayload->nonce);

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -150,6 +150,7 @@ class ImplicitGrant extends \League\OAuth2\Server\Grant\ImplicitGrant
             $idToken->setIat(new \DateTimeImmutable());
             $idToken->setAuthTime(new \DateTime());
             $idToken->setNonce($authorizationRequest->getNonce());
+            $idToken->setIdentifier($this->generateUniqueIdentifier());
 
             // If there is no access token returned, include the supported claims
             if ($authorizationRequest->getResponseType() == 'id_token') {


### PR DESCRIPTION
Add a property to set the identifier (`jti`) instead of the bogus value. Implementers can set the identifier based on the TOKEN_POPULATED event (#16).