### PR TITLE
Use the Session service for the implicit grant

### DIFF
--- a/src/Entities/IdToken.php
+++ b/src/Entities/IdToken.php
@@ -102,7 +102,7 @@ class IdToken
     /**
      * Get the value of expiration
      */
-    public function getExpiration() : DateTimeImmutable
+    public function getExpiration() : \DateTimeInterface
     {
         return $this->expiration;
     }
@@ -112,7 +112,7 @@ class IdToken
      *
      * @return  self
      */
-    public function setExpiration(\DateTimeImmutable $expiration)
+    public function setExpiration(\DateTimeInterface $expiration)
     {
         $this->expiration = $expiration;
 
@@ -132,7 +132,7 @@ class IdToken
      *
      * @return  self
      */
-    public function setIat(\DateTimeImmutable $iat)
+    public function setIat(\DateTimeInterface $iat)
     {
         $this->iat = $iat;
 
@@ -152,7 +152,7 @@ class IdToken
      *
      * @return  self
      */
-    public function setAuthTime(\DateTime $authTime)
+    public function setAuthTime(\DateTimeInterface $authTime)
     {
         $this->authTime = $authTime;
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -2,7 +2,7 @@
 
 namespace Idaas\OpenID;
 
-class Session
+class Session implements SessionInterface
 {
     public function getAuthTime()
     {

--- a/src/SessionInterface.php
+++ b/src/SessionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Idaas\OpenID;
+
+interface SessionInterface
+{
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getAuthTime();
+}


### PR DESCRIPTION
The auth code grant already makes use of the Session service to get information about the session (auth time), which the implicit grant doesn't / didn't properly do. Previously (pre #16) the Session service was resolved using Laraval, while it could/should have been injected as a service into the grant, like the auth code grant does.

This also extracts an interface for the Session service. This as the implementation (most likely) has to be framework aware as it must use the time of the original login, in case the user was already logged in when the authorization endpoint was called (and not "now" / the time of calling the authorization endpoint like the current implementation does).

Also refactored usages of DateTime & DateTimeImmutable to work based on the DateTimeInterface. And where applicable simplified code by "modifying" an immutable instance (which returns a new, updated, instance, instead of modifying the existing instance).