### PR TITLE
Improve ResponseHandler

### DIFF
--- a/src/ResponseHandler.php
+++ b/src/ResponseHandler.php
@@ -23,14 +23,10 @@ class ResponseHandler
     {
         foreach ($this->handlers as $handler) {
             if ($handler->canRespondToAuthorizationRequest($authenticationRequest)) {
-                $response = $handler->generateResponse($authenticationRequest, $code);
+                return $handler->generateResponse($authenticationRequest, $code);
             }
         }
 
-        if ($response == null) {
-            throw OAuthServerException::invalidRequest('response_mode', 'No valid response_mode provided');
-        }
-
-        return $response;
+        throw OAuthServerException::invalidRequest('response_mode', 'No valid response_mode provided');
     }
 }


### PR DESCRIPTION
* Don't continue checking handler when one (/first) matches
* Fix "Undefined variable $response" error when no handler matched