### PR TITLE
add (return) type hints to overriden methods

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -62,7 +62,7 @@ class AuthCodeGrant extends \League\OAuth2\Server\Grant\AuthCodeGrant
         }
     }
 
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return 'authorization_code_oidc';
     }
@@ -70,7 +70,7 @@ class AuthCodeGrant extends \League\OAuth2\Server\Grant\AuthCodeGrant
     /**
      * {@inheritdoc}
      */
-    public function canRespondToAuthorizationRequest(ServerRequestInterface $request)
+    public function canRespondToAuthorizationRequest(ServerRequestInterface $request): bool
     {
         $result = parent::canRespondToAuthorizationRequest($request);
 
@@ -82,7 +82,7 @@ class AuthCodeGrant extends \League\OAuth2\Server\Grant\AuthCodeGrant
         return $result;
     }
 
-    public function canRespondToAccessTokenRequest(ServerRequestInterface $request)
+    public function canRespondToAccessTokenRequest(ServerRequestInterface $request): bool
     {
         $requestParameters = (array) $request->getParsedBody();
         //FIXME: for some reason, the unit test complete if the next three lines are removed
@@ -100,7 +100,7 @@ class AuthCodeGrant extends \League\OAuth2\Server\Grant\AuthCodeGrant
     /**
      * {@inheritdoc}
      */
-    public function validateAuthorizationRequest(ServerRequestInterface $request)
+    public function validateAuthorizationRequest(ServerRequestInterface $request): AuthorizationRequest
     {
         $result = parent::validateAuthorizationRequest($request);
         
@@ -160,7 +160,7 @@ class AuthCodeGrant extends \League\OAuth2\Server\Grant\AuthCodeGrant
         ServerRequestInterface $request,
         ResponseTypeInterface $responseType,
         \DateInterval $accessTokenTTL
-    ) {
+    ): ResponseTypeInterface {
         /**
          * @var BearerTokenResponse $result
          */
@@ -211,7 +211,7 @@ class AuthCodeGrant extends \League\OAuth2\Server\Grant\AuthCodeGrant
     /**
      * {@inheritdoc}
      */
-    public function completeAuthorizationRequest(AuthorizationRequest $authorizationRequest)
+    public function completeAuthorizationRequest(AuthorizationRequest $authorizationRequest): ResponseTypeInterface
     {
         if (!($authorizationRequest instanceof AuthenticationRequest)) {
             throw OAuthServerException::invalidRequest('not possible');

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -13,6 +13,7 @@ use League\OAuth2\Server\Entities\UserEntityInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
 use League\OAuth2\Server\ResponseTypes\RedirectResponse;
+use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class ImplicitGrant extends \League\OAuth2\Server\Grant\ImplicitGrant
@@ -58,12 +59,12 @@ class ImplicitGrant extends \League\OAuth2\Server\Grant\ImplicitGrant
         $this->queryDelimiter = $queryDelimiter;
     }
 
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return 'implicit_oidc';
     }
 
-    public function canRespondToAuthorizationRequest(ServerRequestInterface $request)
+    public function canRespondToAuthorizationRequest(ServerRequestInterface $request): bool
     {
         $result = (isset($request->getQueryParams()['response_type'])
             && ($request->getQueryParams()['response_type'] === 'id_token token' || $request->getQueryParams()['response_type'] === 'id_token' || $request->getQueryParams()['response_type'] === 'token')
@@ -75,7 +76,7 @@ class ImplicitGrant extends \League\OAuth2\Server\Grant\ImplicitGrant
         return $result && ($scopes && in_array('openid', explode(' ', $scopes)));
     }
 
-    public function validateAuthorizationRequest(ServerRequestInterface $request)
+    public function validateAuthorizationRequest(ServerRequestInterface $request): AuthorizationRequest
     {
         $result = parent::validateAuthorizationRequest($request);
 
@@ -127,7 +128,7 @@ class ImplicitGrant extends \League\OAuth2\Server\Grant\ImplicitGrant
         return $result;
     }
 
-    public function completeAuthorizationRequest(AuthorizationRequest $authorizationRequest)
+    public function completeAuthorizationRequest(AuthorizationRequest $authorizationRequest): ResponseTypeInterface
     {
         if (!($authorizationRequest instanceof AuthenticationRequest)) {
             throw OAuthServerException::invalidRequest('not possible');

--- a/src/ResponseTypes/BearerTokenResponse.php
+++ b/src/ResponseTypes/BearerTokenResponse.php
@@ -27,7 +27,7 @@ class BearerTokenResponse extends LeagueBearerTokenResponse implements ResponseT
         return $this->accessToken;
     }
 
-    protected function getExtraParams(AccessTokenEntityInterface $accessToken)
+    protected function getExtraParams(AccessTokenEntityInterface $accessToken): array
     {
 
         /*


### PR DESCRIPTION
Symfony logs deprecations for overriden methods when the signature doesn't match that of the parent (based on both actual typehints or PHPDoc). So this fixes these deprecations. This also makes the code "forward" compatible for when the base class (/package) does actually add these typehints.