### PR TITLE
Chain extra claims

### DIFF
--- a/src/Entities/IdToken.php
+++ b/src/Entities/IdToken.php
@@ -32,7 +32,6 @@ class IdToken
 
     public function convertToJWT(CryptKey $privateKey)
     {
-        
         $config = Configuration::forAsymmetricSigner(
             new Sha256(),
             InMemory::plainText($privateKey->getKeyContents()),
@@ -52,7 +51,7 @@ class IdToken
             ->withClaim('nonce', $this->getNonce());
 
         foreach ($this->extra as $key => $value) {
-            $token->withClaim($key, $value);
+            $token = $token->withClaim($key, $value);
         }
 
         return $token->getToken($config->signer(), $config->signingKey());


### PR DESCRIPTION
The way `lcobucci/jwt` adds claims to the token has changed in `v5.x` and this breaks the `IdToken`
(See commit: https://github.com/lcobucci/jwt/commit/3c04dd998ce254d2d69aa6cd9cc73ae73a9b17c4).