### PR TITLE
Add compatibility with league/oauth2-server 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     },
     "require": {
-        "league/oauth2-server": "^8",
+        "league/oauth2-server": "^8|^9",
         "lcobucci/jwt": "^4.3|^5.0",
         "nyholm/psr7": "^1.3"
     },

--- a/src/AdvancedResourceServer.php
+++ b/src/AdvancedResourceServer.php
@@ -31,7 +31,7 @@ class AdvancedResourceServer extends ResourceServer
     /**
      * @return AuthorizationValidatorInterface
      */
-    protected function getAuthorizationValidator()
+    protected function getAuthorizationValidator(): AuthorizationValidatorInterface
     {
         return $this->authorizationValidator;
     }

--- a/src/Entities/AccessTokenEntityInterface.php
+++ b/src/Entities/AccessTokenEntityInterface.php
@@ -13,11 +13,4 @@ interface AccessTokenEntityInterface extends LeagueAccessTokenEntityInterface
      * @return ClaimEntityInterface[]
      */
     public function getClaims();
-
-    /**
-     * Return an array of scopes associated with the token
-     *
-     * @return ScopeEntityInterface[]
-     */
-    public function getScopes();
 }

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -16,6 +16,7 @@ use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
+use League\OAuth2\Server\RequestTypes\AuthorizationRequestInterface;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use LogicException;
 use Psr\Http\Message\ServerRequestInterface;

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -233,7 +233,7 @@ class AuthCodeGrant extends \League\OAuth2\Server\Grant\AuthCodeGrant
     /**
      * {@inheritdoc}
      */
-    public function completeAuthorizationRequest(AuthorizationRequest $authorizationRequest): ResponseTypeInterface
+    public function completeAuthorizationRequest(AuthorizationRequest|AuthorizationRequestInterface $authorizationRequest): ResponseTypeInterface
     {
         if (!($authorizationRequest instanceof AuthenticationRequest)) {
             throw OAuthServerException::invalidRequest('not possible');

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -294,4 +294,9 @@ class AuthCodeGrant extends \League\OAuth2\Server\Grant\AuthCodeGrant
             );
         }
     }
+
+    protected function createAuthorizationRequest(): AuthenticationRequest
+    {
+        return new AuthenticationRequest();
+    }
 }

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -33,11 +33,6 @@ class AuthCodeGrant extends \League\OAuth2\Server\Grant\AuthCodeGrant
     protected $claimRepository;
 
     /**
-     * @var AccessTokenRepositoryInterface
-     */
-    protected $accessTokenRepository;
-
-    /**
      * @param AuthCodeRepositoryInterface     $authCodeRepository
      * @param RefreshTokenRepositoryInterface $refreshTokenRepository
      * @param \DateInterval                   $authCodeTTL

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -138,7 +138,7 @@ class ImplicitGrant extends \League\OAuth2\Server\Grant\ImplicitGrant
         return $result;
     }
 
-    public function completeAuthorizationRequest(AuthorizationRequest $authorizationRequest): ResponseTypeInterface
+    public function completeAuthorizationRequest(AuthorizationRequest|AuthorizationRequestInterface $authorizationRequest): ResponseTypeInterface
     {
         if (!($authorizationRequest instanceof AuthenticationRequest)) {
             throw OAuthServerException::invalidRequest('not possible');

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -256,7 +256,7 @@ class ImplicitGrant extends \League\OAuth2\Server\Grant\ImplicitGrant
         );
     }
 
-    public function setAccessTokenRepository(AccessTokenRepositoryInterface $accessTokenRepository)
+    public function setAccessTokenRepository(AccessTokenRepositoryInterface $accessTokenRepository): void
     {
         if (!($accessTokenRepository instanceof \Idaas\OpenID\Repositories\AccessTokenRepositoryInterface)) {
             throw new \LogicException('The access token repository must be an instance of Idaas\OpenID\Repositories\AccessTokenRepositoryInterface');

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -24,11 +24,6 @@ class ImplicitGrant extends \League\OAuth2\Server\Grant\ImplicitGrant
     private $idTokenTTL;
     private $queryDelimiter;
 
-    /**
-     * @var UserRepositoryInterface
-     */
-    protected $userRepository;
-
     protected $claimRepositoryInterface;
 
     /**

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -12,6 +12,7 @@ use League\OAuth2\Server\Entities\UserEntityInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
+use League\OAuth2\Server\RequestTypes\AuthorizationRequestInterface;
 use League\OAuth2\Server\ResponseTypes\RedirectResponse;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/src/IdTokenEvent.php
+++ b/src/IdTokenEvent.php
@@ -5,35 +5,67 @@ namespace Idaas\OpenID;
 use Idaas\OpenID\Entities\IdToken;
 use League\Event\Event;
 use League\OAuth2\Server\Grant\GrantTypeInterface;
+use Psr\EventDispatcher\StoppableEventInterface;
 
-class IdTokenEvent extends Event
-{
-    public const TOKEN_POPULATED = 'id_token.populated';
-
-    /**
-     * @var IdToken
-     */
-    private $idToken;
-
-    /**
-     * @var GrantTypeInterface
-     */
-    private $grantType;
-
-    public function __construct($name, IdToken $idToken, GrantTypeInterface $grantType)
+if (class_exists(Event::class)) {
+    class IdTokenEvent extends Event
     {
-        parent::__construct($name);
-        $this->idToken = $idToken;
-        $this->grantType = $grantType;
+        use IdTokenEventTrait;
+
+        public const TOKEN_POPULATED = 'id_token.populated';
+
+        public function __construct($name, IdToken $idToken, GrantTypeInterface $grantType)
+        {
+            parent::__construct($name);
+            $this->idToken = $idToken;
+            $this->grantType = $grantType;
+        }
     }
-
-    public function getIdToken()
+} else {
+    class IdTokenEvent implements StoppableEventInterface
     {
-        return $this->idToken;
-    }
+        use IdTokenEventTrait;
 
-    public function getGrantType()
-    {
-        return $this->grantType;
+        public const TOKEN_POPULATED = 'id_token.populated';
+
+        /**
+         * @var string
+         */
+        private $name;
+
+        /**
+         * @var bool
+         */
+        protected $propagationStopped = false;
+
+        public function __construct($name, IdToken $idToken, GrantTypeInterface $grantType)
+        {
+            $this->name = $name;
+            $this->idToken = $idToken;
+            $this->grantType = $grantType;
+        }
+
+        /**
+         * @return $this
+         */
+        public function stopPropagation()
+        {
+            $this->propagationStopped = true;
+
+            return $this;
+        }
+
+        public function isPropagationStopped(): bool
+        {
+            return $this->propagationStopped;
+        }
+
+        /**
+         * @return string
+         */
+        public function getName()
+        {
+            return $this->name;
+        }
     }
 }

--- a/src/IdTokenEventTrait.php
+++ b/src/IdTokenEventTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Idaas\OpenID;
+
+use Idaas\OpenID\Entities\IdToken;
+use League\OAuth2\Server\Grant\GrantTypeInterface;
+
+trait IdTokenEventTrait
+{
+    /**
+     * @var IdToken
+     */
+    private $idToken;
+
+    /**
+     * @var GrantTypeInterface
+     */
+    private $grantType;
+
+    public function getIdToken()
+    {
+        return $this->idToken;
+    }
+
+    public function getGrantType()
+    {
+        return $this->grantType;
+    }
+}

--- a/src/RequestTypes/AuthenticationRequest.php
+++ b/src/RequestTypes/AuthenticationRequest.php
@@ -33,12 +33,24 @@ class AuthenticationRequest extends AuthorizationRequest
         $result = new self();
 
         $result->setClient($authorizationRequest->getClient());
-        $result->setCodeChallenge($authorizationRequest->getCodeChallenge());
-        $result->setCodeChallengeMethod($authorizationRequest->getCodeChallengeMethod());
         $result->setGrantTypeId($authorizationRequest->getGrantTypeId());
-        $result->setRedirectUri($authorizationRequest->getRedirectUri());
         $result->setScopes($authorizationRequest->getScopes());
-        $result->setState($authorizationRequest->getState());
+
+        if ($authorizationRequest->getCodeChallenge() !== null) {
+            $result->setCodeChallenge($authorizationRequest->getCodeChallenge());
+        }
+
+        if ($authorizationRequest->getCodeChallengeMethod() !== null) {
+            $result->setCodeChallengeMethod($authorizationRequest->getCodeChallengeMethod());
+        }
+
+        if ($authorizationRequest->getRedirectUri() !== null) {
+            $result->setRedirectUri($authorizationRequest->getRedirectUri());
+        }
+
+        if ($authorizationRequest->getState() !== null) {
+            $result->setState($authorizationRequest->getState());
+        }
 
         if ($authorizationRequest->getUser() !== null) {
             $result->setUser($authorizationRequest->getUser());

--- a/src/RequestTypes/AuthenticationRequest.php
+++ b/src/RequestTypes/AuthenticationRequest.php
@@ -23,6 +23,8 @@ class AuthenticationRequest extends AuthorizationRequest
 
     /**
      * @return AuthenticationRequest
+     *
+     * @deprecated Not really used anymore with league/oauth2-server 9 as AuthenticationRequest is populated by league/oauth2-server using `createAuthorizationRequest()`
      */
     public static function fromAuthorizationRequest(AuthorizationRequest $authorizationRequest)
     {

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -48,9 +48,12 @@ class BasicTest extends TestCase
 
         $server->enableGrantType($grant);
 
+        $client = new ClientEntity();
+        $client->setIdentifier('test');
+
         $authRequest = new AuthenticationRequest();
         $authRequest->setAuthorizationApproved(true);
-        $authRequest->setClient(new ClientEntity());
+        $authRequest->setClient($client);
         $authRequest->setGrantTypeId('authorization_code_oidc');
         $authRequest->setUser(new UserEntity());
         $authRequest->setRedirectUri('http://redirect/destination');

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -121,6 +121,7 @@ class AuthCodeGrantTest extends TestCase
                 'response_type' => 'code',
                 'client_id'     => 'foo',
                 'redirect_uri'  => 'http://foo/bar',
+                'code_challenge' => self::CODE_CHALLENGE,
             ]
         );
 
@@ -224,6 +225,7 @@ class AuthCodeGrantTest extends TestCase
             new DateInterval('PT10M'),
             new DateInterval('PT10M')
         );
+        $grant->setDefaultScope('');
 
         $grant->setClientRepository($clientRepositoryMock);
 
@@ -257,6 +259,7 @@ class AuthCodeGrantTest extends TestCase
             new DateInterval('PT10M'),
             new DateInterval('PT10M')
         );
+        $grant->setDefaultScope('');
 
         $grant->setClientRepository($clientRepositoryMock);
 
@@ -290,6 +293,7 @@ class AuthCodeGrantTest extends TestCase
             new DateInterval('PT10M'),
             new DateInterval('PT10M')
         );
+        $grant->setDefaultScope('');
 
         $grant->setClientRepository($clientRepositoryMock);
 
@@ -468,9 +472,12 @@ class AuthCodeGrantTest extends TestCase
 
     public function testCompleteAuthorizationRequest()
     {
+        $client = new ClientEntity();
+        $client->setIdentifier('test');
+
         $authRequest = new AuthenticationRequest();
         $authRequest->setAuthorizationApproved(true);
-        $authRequest->setClient(new ClientEntity());
+        $authRequest->setClient($client);
         $authRequest->setGrantTypeId('authorization_code');
         $authRequest->setUser(new UserEntity());
         $authRequest->setRedirectUri('http://redirect/destination');
@@ -535,6 +542,7 @@ class AuthCodeGrantTest extends TestCase
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
         $scopeEntity = new ScopeEntity();
@@ -577,7 +585,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id' => \uniqid(),
                             'expire_time'  => \time() + 3600,
                             'client_id'    => 'foo',
-                            'user_id'      => 123,
+                            'user_id'      => '123',
                             'redirect_uri' => 'http://foo/bar',
 
                             'scopes'       => ['foo','openid'],
@@ -605,6 +613,7 @@ class AuthCodeGrantTest extends TestCase
         $client->setIdentifier('foo');
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
         $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
@@ -641,7 +650,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id' => \uniqid(),
                             'client_id' => 'foo',
                             'expire_time'  => \time() + 3600,
-                            'user_id'      => 123,
+                            'user_id'      => '123',
                             'redirect_uri' => 'http://foo/bar',
 
                             'scopes'       => ['foo','openid'],
@@ -709,7 +718,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id' => \uniqid(),
                             'expire_time'  => \time() + 3600,
                             'client_id'    => 'foo',
-                            'user_id'      => 123,
+                            'user_id'      => '123',
                             'redirect_uri' => 'http://foo/bar',
 
                             'scopes'       => ['foo','openid'],
@@ -780,7 +789,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id' => \uniqid(),
                             'expire_time'  => \time() + 3600,
                             'client_id'    => 'foo',
-                            'user_id'      => 123,
+                            'user_id'      => '123',
                             'redirect_uri' => 'http://foo/bar',
 
                             'scopes'       => ['foo','openid'],
@@ -809,6 +818,7 @@ class AuthCodeGrantTest extends TestCase
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
         $scopeEntity = new ScopeEntity();
@@ -854,7 +864,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id'          => \uniqid(),
                             'expire_time'           => \time() + 3600,
                             'client_id'             => 'foo',
-                            'user_id'               => 123,
+                            'user_id'               => '123',
                             'redirect_uri'          => 'http://foo/bar',
                             'code_challenge'        => self::CODE_VERIFIER,
                             'code_challenge_method' => 'plain',
@@ -885,6 +895,7 @@ class AuthCodeGrantTest extends TestCase
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
         $scopeEntity = new ScopeEntity();
@@ -930,7 +941,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id'          => \uniqid(),
                             'expire_time'           => \time() + 3600,
                             'client_id'             => 'foo',
-                            'user_id'               => 123,
+                            'user_id'               => '123',
                             'redirect_uri'          => 'http://foo/bar',
                             'code_challenge'        => self::CODE_CHALLENGE,
                             'code_challenge_method' => 'S256',
@@ -960,6 +971,7 @@ class AuthCodeGrantTest extends TestCase
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $claimRepositoryMock = $this->getMockBuilder(ClaimRepositoryInterface::class)->getMock();
         $claimRepositoryMock->method('claimsRequestToEntities')->willReturn([new ClaimEntity('sub')]);
@@ -1051,6 +1063,7 @@ class AuthCodeGrantTest extends TestCase
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
@@ -1119,7 +1132,7 @@ class AuthCodeGrantTest extends TestCase
                             'refresh_token_id' => 'zyxwvu',
                             'access_token_id'  => 'abcdef',
                             'scopes'           => ['foo'],
-                            'user_id'          => 123,
+                            'user_id'          => '123',
                             'expire_time'      => \time() + 3600,
                         ]
                     )
@@ -1166,7 +1179,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id' => \uniqid(),
                             'expire_time'  => \time() - 3600,
                             'client_id'    => 'foo',
-                            'user_id'      => 123,
+                            'user_id'      => '123',
                             'scopes'       => ['foo'],
                             'redirect_uri' => 'http://foo/bar',
                         ]
@@ -1191,6 +1204,7 @@ class AuthCodeGrantTest extends TestCase
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
@@ -1228,7 +1242,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id' => \uniqid(),
                             'expire_time'  => \time() + 3600,
                             'client_id'    => 'foo',
-                            'user_id'      => 123,
+                            'user_id'      => '123',
                             'redirect_uri' => 'http://foo/bar',
 
                             'scopes'       => ['foo','openid'],
@@ -1247,7 +1261,10 @@ class AuthCodeGrantTest extends TestCase
             $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
         } catch (OAuthServerException $e) {
             $this->assertEquals($e->getHint(), 'Authorization code has been revoked');
-            $this->assertEquals($e->getErrorType(), 'invalid_request');
+            $this->assertThat($e->getErrorType(), $this->logicalOr(
+                $this->equalTo('invalid_grant'), // league/oauth2-server 9
+                $this->equalTo('invalid_request') // league/oauth2-server 8
+            ));
         }
     }
 
@@ -1259,6 +1276,7 @@ class AuthCodeGrantTest extends TestCase
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
@@ -1293,7 +1311,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id' => \uniqid(),
                             'expire_time'  => \time() + 3600,
                             'client_id'    => 'bar',
-                            'user_id'      => 123,
+                            'user_id'      => '123',
                             'redirect_uri' => 'http://foo/bar',
 
                             'scopes'       => ['foo','openid'],
@@ -1323,6 +1341,7 @@ class AuthCodeGrantTest extends TestCase
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
@@ -1359,7 +1378,10 @@ class AuthCodeGrantTest extends TestCase
             /* @var StubResponseType $response */
             $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
         } catch (OAuthServerException $e) {
-            $this->assertEquals($e->getHint(), 'Cannot decrypt the authorization code');
+            $this->assertThat($e->getHint(), $this->logicalOr(
+                $this->equalTo('Cannot validate the provided authorization code'), // league/oauth2-server 9.1+
+                $this->equalTo('Cannot decrypt the authorization code') // league/oauth2-server 8 and 9.0
+            ));
         }
     }
 
@@ -1371,6 +1393,7 @@ class AuthCodeGrantTest extends TestCase
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
         $scopeEntity = new ScopeEntity();
@@ -1415,7 +1438,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id'          => \uniqid(),
                             'expire_time'           => \time() + 3600,
                             'client_id'             => 'foo',
-                            'user_id'               => 123,
+                            'user_id'               => '123',
                             'scopes'                => ['foo'],
                             'redirect_uri'          => 'http://foo/bar',
                             'code_challenge'        => 'foobar',
@@ -1442,6 +1465,7 @@ class AuthCodeGrantTest extends TestCase
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
         $scopeEntity = new ScopeEntity();
@@ -1486,7 +1510,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id'          => \uniqid(),
                             'expire_time'           => \time() + 3600,
                             'client_id'             => 'foo',
-                            'user_id'               => 123,
+                            'user_id'               => '123',
                             'scopes'                => ['foo'],
                             'redirect_uri'          => 'http://foo/bar',
                             'code_challenge'        => 'foobar',
@@ -1513,6 +1537,7 @@ class AuthCodeGrantTest extends TestCase
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
         $scopeEntity = new ScopeEntity();
@@ -1557,7 +1582,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id'          => \uniqid(),
                             'expire_time'           => \time() + 3600,
                             'client_id'             => 'foo',
-                            'user_id'               => 123,
+                            'user_id'               => '123',
                             'scopes'                => ['foo'],
                             'redirect_uri'          => 'http://foo/bar',
                             'code_challenge'        => self::CODE_CHALLENGE,
@@ -1584,6 +1609,7 @@ class AuthCodeGrantTest extends TestCase
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
         $scopeEntity = new ScopeEntity();
@@ -1628,7 +1654,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id'          => \uniqid(),
                             'expire_time'           => \time() + 3600,
                             'client_id'             => 'foo',
-                            'user_id'               => 123,
+                            'user_id'               => '123',
                             'scopes'                => ['foo'],
                             'redirect_uri'          => 'http://foo/bar',
                             'code_challenge'        => 'R7T1y1HPNFvs1WDCrx4lfoBS6KD2c71pr8OHvULjvv8',
@@ -1655,6 +1681,7 @@ class AuthCodeGrantTest extends TestCase
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
         $scopeEntity = new ScopeEntity();
@@ -1698,7 +1725,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id'          => \uniqid(),
                             'expire_time'           => \time() + 3600,
                             'client_id'             => 'foo',
-                            'user_id'               => 123,
+                            'user_id'               => '123',
                             'scopes'                => ['foo'],
                             'redirect_uri'          => 'http://foo/bar',
                             'code_challenge'        => 'foobar',
@@ -1719,9 +1746,12 @@ class AuthCodeGrantTest extends TestCase
 
     public function testAuthCodeRepositoryUniqueConstraintCheck()
     {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+
         $authRequest = new AuthenticationRequest();
         $authRequest->setAuthorizationApproved(true);
-        $authRequest->setClient(new ClientEntity());
+        $authRequest->setClient($client);
         $authRequest->setGrantTypeId('authorization_code');
         $authRequest->setUser(new UserEntity());
         $authRequest->setRedirectUri('http://redirect/destination');
@@ -1867,7 +1897,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id' => \uniqid(),
                             'expire_time'  => \time() + 3600,
                             'client_id'    => 'foo',
-                            'user_id'      => 123,
+                            'user_id'      => '123',
                             'redirect_uri' => 'http://foo/bar',
 
                             'scopes'       => ['foo','openid'],
@@ -1938,7 +1968,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id' => \uniqid(),
                             'expire_time'  => \time() + 3600,
                             'client_id'    => 'foo',
-                            'user_id'      => 123,
+                            'user_id'      => '123',
                             'redirect_uri' => 'http://foo/bar',
 
                             'scopes'       => ['foo','openid'],
@@ -2012,7 +2042,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id' => \uniqid(),
                             'expire_time'  => \time() + 3600,
                             'client_id'    => 'foo',
-                            'user_id'      => 123,
+                            'user_id'      => '123',
                             'scopes'       => ['foo'],
                             'redirect_uri' => 'http://foo/bar',
 


### PR DESCRIPTION
Add compatibility with league/oauth2-server 9 while maintaining support with version 8 as well.

Tested by using this branch both with league/oauth2-server 8 & 9. And for both versions going through the steps of oauthdebugger.com including decoding the id_token and requesting the user info endpoint. Which was successful without  making any further changes to the code of my project.