### PR TITLE
fix php84 implicit parameter type nullable deprecation

### DIFF
--- a/src/AdvancedResourceServer.php
+++ b/src/AdvancedResourceServer.php
@@ -22,7 +22,7 @@ class AdvancedResourceServer extends ResourceServer
      */
     public function __construct(
         AccessTokenRepositoryInterface $accessTokenRepository,
-        AuthorizationValidatorInterface $authorizationValidator = null
+        ?AuthorizationValidatorInterface $authorizationValidator = null
     ) {
         $this->accessTokenRepository = $accessTokenRepository;
         $this->authorizationValidator = $authorizationValidator;

--- a/src/Repositories/ClaimRepositoryInterface.php
+++ b/src/Repositories/ClaimRepositoryInterface.php
@@ -25,5 +25,5 @@ interface ClaimRepositoryInterface extends RepositoryInterface
      */
     public function getClaimsByScope(ScopeEntityInterface $scope): iterable;
 
-    public function claimsRequestToEntities(array $json = null);
+    public function claimsRequestToEntities(?array $json = null);
 }


### PR DESCRIPTION
Php 8.4 deprecates parameter types to be null implicitly. It should be explicit as of php84, it raises a deprecation warning